### PR TITLE
Fixing link to the spec

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # ssb-http-invite-client
 
-Plugin that implements the client-side of the [SSB HTTP Invites spec](https://ssb-ngi-pointer.github.io/ssb-http-invite-spec). This is supposed to be installed and used on **apps** that make remote calls to servers, thus *clients*.
+Plugin that implements the client-side of the [SSB HTTP Invites spec](https://ssbc.github.io/ssb-http-invite-spec/). This is supposed to be installed and used on **apps** that make remote calls to servers, thus *clients*.
 
 ## Installation
 


### PR DESCRIPTION
The link to the spec broke when the code was moved to ssbc, so this PR fixes the link. 